### PR TITLE
feat(sentry): Session Replay on errors + PII scrub pattern unification

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -10,9 +10,9 @@ Sentry.init({
   // Performance: sample 10% in production
   tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
 
-  // Session replay: off by default (can enable later)
+  // Session replay: capture on errors for debugging (mask all text/inputs by default)
   replaysSessionSampleRate: 0,
-  replaysOnErrorSampleRate: 0,
+  replaysOnErrorSampleRate: process.env.NODE_ENV === "production" ? 0.5 : 0,
 
   // Security: no PII
   sendDefaultPii: false,
@@ -52,6 +52,7 @@ Sentry.init({
         "set-cookie",
         "x-api-key",
         "x-forwarded-for",
+        "x-real-ip",
       ];
       for (const header of sensitiveHeaders) {
         if (event.request.headers[header]) {
@@ -60,11 +61,12 @@ Sentry.init({
       }
     }
 
-    // Scrub PII from request data
+    // Scrub PII from request data (SSoT — keep in sync with workers-hub sentry.ts)
     if (event.request?.data && typeof event.request.data === "string") {
-      event.request.data = event.request.data
-        .replace(/"(password|token|secret|api_key|apiKey|access_token|refresh_token)":\s*"[^"]*"/gi, '"$1": "[Filtered]"')
-        .replace(/"(email)":\s*"[^"]*"/gi, '"$1": "[Filtered]"');
+      event.request.data = event.request.data.replace(
+        /"(password|token|secret|api_key|apiKey|access_token|refresh_token|client_secret|encryption_key|email)":\s*"[^"]*"/gi,
+        '"$1": "[Filtered]"',
+      );
     }
 
     return event;


### PR DESCRIPTION
## Summary
- Enable `replaysOnErrorSampleRate: 0.5` in production (was 0) for error debugging via Session Replay
- Unify PII scrub patterns with workers-hub: add `client_secret`, `encryption_key` to body scrub regex
- Add `x-real-ip` to sensitive header scrub list
- Consolidate two `.replace()` calls into single regex for consistency

## Test plan
- [ ] Verify Sentry Session Replay captures on error in production
- [ ] Verify PII patterns match workers-hub `sentry.ts` (SSoT comment added)
- [ ] Monitor Sentry replay quota usage after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)